### PR TITLE
Implement developer role and dashboard

### DIFF
--- a/Models/User.cs
+++ b/Models/User.cs
@@ -6,5 +6,6 @@ namespace VibeQuestApp.Models
     {
         public string DisplayName { get; set; } = string.Empty;
         public string AvatarUrl { get; set; } = string.Empty;
+        public bool IsDeveloper { get; set; } = false;
     }
 }

--- a/Pages/DeveloperDashboard.razor
+++ b/Pages/DeveloperDashboard.razor
@@ -1,0 +1,115 @@
+@page "/developer/dashboard"
+@using System.ComponentModel.DataAnnotations
+@using Microsoft.EntityFrameworkCore
+@using VibeQuestApp.Data
+@using VibeQuestApp.Models
+@inject AppDbContext Db
+@inject UserSessionService Session
+
+<h3>Developer Dashboard</h3>
+
+@if (Session.CurrentUser is null || !Session.CurrentUser.IsDeveloper)
+{
+    <p class="text-danger">Access denied.</p>
+}
+else
+{
+    <h4>Create New User</h4>
+    <EditForm Model="newUser" OnValidSubmit="CreateUser">
+        <DataAnnotationsValidator />
+        <div class="row g-2 mb-3">
+            <div class="col">
+                <InputText class="form-control" placeholder="Email" @bind-Value="newUser.Email" />
+            </div>
+            <div class="col">
+                <InputText class="form-control" type="password" placeholder="Password" @bind-Value="newUser.Password" />
+            </div>
+            <div class="col">
+                <InputText class="form-control" placeholder="Display Name" @bind-Value="newUser.DisplayName" />
+            </div>
+            <div class="col d-flex align-items-center">
+                <label class="form-check-label me-2">Developer?</label>
+                <InputCheckbox class="form-check-input" @bind-Value="newUser.IsDeveloper" />
+            </div>
+            <div class="col">
+                <button class="btn btn-primary" type="submit">Create</button>
+            </div>
+        </div>
+    </EditForm>
+
+    <h4 class="mt-4">All Users</h4>
+    @if (users == null)
+    {
+        <p>Loading...</p>
+    }
+    else
+    {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Display Name</th>
+                    <th>Developer</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var u in users)
+                {
+                    <tr>
+                        <td>@u.Email</td>
+                        <td><InputText class="form-control" @bind-Value="u.DisplayName" /></td>
+                        <td><InputCheckbox @bind-Value="u.IsDeveloper" /></td>
+                        <td><button class="btn btn-sm btn-success" @onclick="() => SaveUser(u)">Save</button></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+}
+
+@code {
+    private List<User>? users;
+    private NewUser newUser = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Session.CurrentUser?.IsDeveloper == true)
+        {
+            users = await Db.Users.ToListAsync();
+        }
+    }
+
+    private async Task CreateUser()
+    {
+        var user = new User
+        {
+            Email = newUser.Email!,
+            UserName = newUser.Email!,
+            DisplayName = newUser.DisplayName ?? string.Empty,
+            IsDeveloper = newUser.IsDeveloper,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword(newUser.Password!)
+        };
+
+        Db.Users.Add(user);
+        await Db.SaveChangesAsync();
+        users = await Db.Users.ToListAsync();
+        newUser = new();
+    }
+
+    private async Task SaveUser(User user)
+    {
+        Db.Users.Update(user);
+        await Db.SaveChangesAsync();
+    }
+
+    private class NewUser
+    {
+        [Required, EmailAddress]
+        public string? Email { get; set; }
+        [Required]
+        public string? Password { get; set; }
+        public string? DisplayName { get; set; }
+        public bool IsDeveloper { get; set; }
+    }
+}

--- a/Pages/Onboarding/Step3AccountSetup.razor
+++ b/Pages/Onboarding/Step3AccountSetup.razor
@@ -89,6 +89,7 @@
         var user = new User
         {
             Email = Email,
+            UserName = Email,
             PasswordHash = hashed
         };
 
@@ -114,12 +115,7 @@
         Db.HeroProfiles.Add(profile);
         await Db.SaveChangesAsync();
 
-        Session.SetUser(new User
-        {
-            Id = user.Id,
-            Email = user.Email,
-            AvatarUrl = profile.AvatarUrl
-        });
+        Session.SetUser(user);
 
         return true;
     }

--- a/Program.cs
+++ b/Program.cs
@@ -58,21 +58,18 @@ using (var scope = app.Services.CreateScope())
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     db.Database.Migrate();
 
-    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
-
     if (!db.Users.Any())
     {
         var testUser = new User
         {
             UserName = "test@example.com",
-            Email = "test@example.com"
+            Email = "test@example.com",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("1234")
         };
 
-        var result = await userManager.CreateAsync(testUser, "1234");
+        db.Users.Add(testUser);
 
-        if (result.Succeeded)
-        {
-            db.HeroProfiles.Add(new HeroProfile
+        db.HeroProfiles.Add(new HeroProfile
             {
                 UserId = testUser.Id,
                 HeroName = "Test1",
@@ -88,29 +85,54 @@ using (var scope = app.Services.CreateScope())
                 TotalXP = 0
             });
 
-            db.Quests.AddRange(
-                new Quest
-                {
-                    UserId = testUser.Id,
-                    Title = "Complete your first quest",
-                    Description = "Mark this task as done to earn XP!",
-                    XpReward = 50,
-                    DueDate = DateTime.Today.AddDays(1),
-                    IsCompleted = false
-                },
-                new Quest
-                {
-                    UserId = testUser.Id,
-                    Title = "Check your profile",
-                    Description = "Make sure your hero info is filled out.",
-                    XpReward = 30,
-                    DueDate = DateTime.Today.AddDays(2),
-                    IsCompleted = false
-                }
-            );
+        db.Quests.AddRange(
+            new Quest
+            {
+                UserId = testUser.Id,
+                Title = "Complete your first quest",
+                Description = "Mark this task as done to earn XP!",
+                XpReward = 50,
+                DueDate = DateTime.Today.AddDays(1),
+                IsCompleted = false
+            },
+            new Quest
+            {
+                UserId = testUser.Id,
+                Title = "Check your profile",
+                Description = "Make sure your hero info is filled out.",
+                XpReward = 30,
+                DueDate = DateTime.Today.AddDays(2),
+                IsCompleted = false
+            }
+        );
 
-            db.SaveChanges();
-        }
+        var devUser = new User
+        {
+            UserName = "dev@example.com",
+            Email = "dev@example.com",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("dev1234"),
+            IsDeveloper = true
+        };
+
+        db.Users.Add(devUser);
+
+        db.HeroProfiles.Add(new HeroProfile
+        {
+            UserId = devUser.Id,
+            HeroName = "DevHero",
+            AvatarUrl = "/uploads/test.jpeg",
+            LifeFocusAreas = "All",
+            PrimaryGoals = "Manage Users",
+            LongTermVision = "Admin",
+            MotivationStyle = "Rewards",
+            CommitmentLevel = "Casual",
+            DailyResetTime = TimeSpan.FromHours(4),
+            Level = 1,
+            CurrentXP = 0,
+            TotalXP = 0
+        });
+
+        db.SaveChanges();
     }
 }
 

--- a/Shared/NavMenu.razor
+++ b/Shared/NavMenu.razor
@@ -35,6 +35,12 @@
             <li class="nav-item">
                 <NavLink class="nav-link" href="/reward-store">Reward Store</NavLink>
             </li>
+            @if (Session.CurrentUser?.IsDeveloper == true)
+            {
+                <li class="nav-item">
+                    <NavLink class="nav-link" href="/developer/dashboard">Developer</NavLink>
+                </li>
+            }
             <li class="nav-item">
                 <a class="nav-link text-danger" href="#" @onclick="Logout">Logout</a>
             </li>


### PR DESCRIPTION
## Summary
- add `IsDeveloper` field to `User`
- allow onboarding to keep the created user in session
- seed a developer account and adjust seeding to use BCrypt
- add a developer dashboard to manage users
- expose dashboard link when logged in as developer

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb86cc0e08330b5cb1ee1c930a67e