### PR TITLE
Add developer login page and role-based redirect

### DIFF
--- a/Pages/DevLogin.razor
+++ b/Pages/DevLogin.razor
@@ -1,0 +1,55 @@
+@page "/dev-login"
+@using System.ComponentModel.DataAnnotations
+@using Microsoft.EntityFrameworkCore
+@using VibeQuestApp.Data
+@using VibeQuestApp.Models
+@inject AppDbContext Db
+@inject NavigationManager NavigationManager
+@inject VibeQuestApp.Services.UserSessionService Session
+@inject ILogger<DevLogin> Logger
+
+<h3>Developer Login</h3>
+
+@if (loginFailed)
+{
+    <div class="alert alert-danger">Invalid credentials or not a developer.</div>
+}
+
+<EditForm Model="loginModel" OnValidSubmit="HandleLogin">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+
+    <div class="mb-3">
+        <label>Email:</label>
+        <InputText class="form-control" @bind-Value="loginModel.Email" />
+    </div>
+
+    <div class="mb-3">
+        <label>Password:</label>
+        <InputText type="password" class="form-control" @bind-Value="loginModel.Password" />
+    </div>
+
+    <button class="btn btn-primary" type="submit">Login</button>
+</EditForm>
+
+@code {
+    private LoginModel loginModel = new();
+    private bool loginFailed = false;
+
+    private async Task HandleLogin()
+    {
+        Logger.LogDebug("Attempting dev login for email: {Email}", loginModel.Email);
+
+        var user = await Db.Users.FirstOrDefaultAsync(u => u.Email == loginModel.Email);
+        if (user != null && user.IsDeveloper && BCrypt.Net.BCrypt.Verify(loginModel.Password, user.PasswordHash))
+        {
+            Logger.LogInformation("Developer login successful for user: {Email}", user.Email);
+            Session.SetUser(user);
+            NavigationManager.NavigateTo("/developer/dashboard");
+            return;
+        }
+
+        Logger.LogWarning("Dev login failed for email: {Email}", loginModel.Email);
+        loginFailed = true;
+    }
+}

--- a/Pages/Login.razor
+++ b/Pages/Login.razor
@@ -33,7 +33,7 @@
 </EditForm>
 
 @code {
-    private LoginModel loginModel = new();
+    private VibeQuestApp.Models.LoginModel loginModel = new();
     private bool loginFailed = false;
 
     private async Task HandleLogin()
@@ -51,7 +51,14 @@
             {
                 Logger.LogInformation("Login successful for user: {Email}", user.Email);
                 Session.SetUser(user);
-                NavigationManager.NavigateTo("/profile");
+                if (user.IsDeveloper)
+                {
+                    NavigationManager.NavigateTo("/developer/dashboard");
+                }
+                else
+                {
+                    NavigationManager.NavigateTo("/profile");
+                }
                 return;
             }
             else
@@ -67,12 +74,4 @@
         loginFailed = true;
     }
 
-    private class LoginModel
-    {
-        [Required]
-        public string Email { get; set; } = string.Empty;
-
-        [Required]
-        public string Password { get; set; } = string.Empty;
-    }
 }

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Users create a “Hero” persona that reflects their growth journey.
 
 | Role         | Access Permissions                          |
 |--------------|---------------------------------------------|
-| Guest        | Get Started, Register, Log In               |
+| Guest        | Get Started, Register, Log In, Dev Login    |
 | User         | Quests, Journal, Rewards, XP Dashboard      |
 | Developer    | Developer Dashboard, Modify Any User        |
 
@@ -215,6 +215,7 @@ Task completion updates
 🔒 Auth Behavior Recap
 Page	Requires Login?	Notes
 /login	❌	Public
+/dev-login	❌	Developer only
 /quests	✅	Authenticated users only
 /developer/dashboard	✅ (Developer)	Devs only via IsDeveloper
 /hero-customize	❌	Public onboarding

--- a/Shared/NavMenu.razor
+++ b/Shared/NavMenu.razor
@@ -17,6 +17,9 @@
             <li class="nav-item">
                 <NavLink class="nav-link" href="/login">Login</NavLink>
             </li>
+            <li class="nav-item">
+                <NavLink class="nav-link" href="/dev-login">Dev Login</NavLink>
+            </li>
         }
         else
         {


### PR DESCRIPTION
## Summary
- add dedicated DevLogin page
- redirect developers to the dashboard when logging in
- show Dev Login link when logged out
- document the new dev login route in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc92ff3208330be743ab133f58eaa